### PR TITLE
Fixed Joystick example

### DIFF
--- a/pages/apidocs.mdx
+++ b/pages/apidocs.mdx
@@ -159,7 +159,7 @@ A component that renders a joystick controller. The joystick can be used to cont
 ```js
 import { Joystick, myPlayer } from 'playroomkit';
 
-new Joystick(myPlayer, {
+new Joystick(myPlayer(), {
   type: "dpad"
 })
 ```


### PR DESCRIPTION
- added missing parentheses to `myPlayer()` in Joystick constructor to return the actual playerstate object